### PR TITLE
Поддержка $this в замыканиях и lasy load связей

### DIFF
--- a/src/Tentacle.php
+++ b/src/Tentacle.php
@@ -20,6 +20,23 @@ trait Tentacle {
 	{
 		static::$tentacles[$name] = $function;
 	}
+
+	public function getAttribute($key)
+	{
+		$attribute = parent::getAttribute($key);
+		if ( ! is_null($attribute))
+		{
+			return $attribute;
+		}
+
+		$camelKey = camel_case($key);
+
+		if (array_key_exists($camelKey, static::$tentacles))
+		{
+			return $this->getRelationshipFromMethod($key, $camelKey);
+		}
+	}
+	
 }
 
 

--- a/src/Tentacle.php
+++ b/src/Tentacle.php
@@ -9,9 +9,8 @@ trait Tentacle {
 		if (array_key_exists($method, static::$tentacles))
 		{
 			$method = static::$tentacles[$method];
-
+			$method = \Closure::bind($method, $this, get_class());
 			return $method($this);
-
 		}
 
 		return parent::__call($method, $parameters);


### PR DESCRIPTION
Первый коммит позволяет использовать `$this` в замыканиях:

``` php
Contact::addRelation('country', function()
{
    return $this->belongsTo('Country', null, null, 'country');
});
```

Второй коммит добавляет lasy load:

``` php
$contact = Contact::first();
echo $contact->country->title;
```
